### PR TITLE
Sort imports and `isinstance` instead of `type`

### DIFF
--- a/commands/commands.py
+++ b/commands/commands.py
@@ -1,6 +1,5 @@
-from typing import Callable
-from commands.courses import *
 from commands.command import Command
+from commands.courses import *
 
 
 commands = {
@@ -22,7 +21,7 @@ commands = {
 def execute(*args: str):
     command = commands
     while True:
-        if type(command) is not dict:
+        if not isinstance(command, dict):
             break
 
         command = command.get(args[0])

--- a/commands/courses.py
+++ b/commands/courses.py
@@ -1,18 +1,14 @@
 import save
+from models.course import Course
+from models.task import Task, TaskStatus
 
-from rich import console
-from rich import text
-from rich.table import Table
+from rich import console, text
 from rich.console import Console
 from rich.markdown import Markdown
+from rich.table import Table
 from rich.text import Text
 
-from models.course import Course
-from typing import Any
-
 from commands.command import Command
-
-from models.task import Task, TaskStatus
 
 
 class AddCourseCommand(Command):

--- a/save.py
+++ b/save.py
@@ -1,7 +1,6 @@
-from storage import storage
-
-from models.task import Task, TaskStatus
 from models.course import Course
+from models.task import Task, TaskStatus
+from storage import storage
 
 
 def get_courses():

--- a/storage.py
+++ b/storage.py
@@ -20,7 +20,7 @@ class StorageCall:
 
     def add_all(self, values: list[dict]):
         for value in values:
-            self.add(value[0], value[1], save=False)
+            self.add(*value[:2], save=False)
 
         save_data(self.data)
 
@@ -40,6 +40,7 @@ class StorageCall:
 def get_data():
     with open("save.json", "r", encoding="utf-8-sig") as f:
         data = json.load(f)
+
 
     return data
 

--- a/storage.py
+++ b/storage.py
@@ -41,7 +41,6 @@ def get_data():
     with open("save.json", "r", encoding="utf-8-sig") as f:
         data = json.load(f)
 
-
     return data
 
 

--- a/tests.py
+++ b/tests.py
@@ -1,6 +1,5 @@
 import sys
 import unittest
-
 from unittest.loader import TestLoader
 
 from tests.test_courses import TestCourses

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,5 +1,6 @@
-from storage import StorageCall
 from unittest.case import TestCase
+
+from storage import StorageCall
 
 
 def get_sample_data():


### PR DESCRIPTION
Some fixes:
- Reorganize **import** according [PEP8](https://www.python.org/dev/peps/pep-0008/#imports)
- Usage of `isinstance` builtins function instead of comparison with `type` function.